### PR TITLE
Fix include for ROS 2 Jazzy compatibility: use planner_exceptions.hpp

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,4 +1,13 @@
 pull_request_rules:
+  - name: backport to jazzy at reviewers discretion
+    conditions:
+      - base=main
+      - "label=backport-jazzy"
+    actions:
+      backport:
+        branches:
+          - jazzy
+
   - name: backport to humble at reviewers discretion
     conditions:
       - base=main

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,46 @@
+pull_request_rules:
+  - name: backport to humble at reviewers discretion
+    conditions:
+      - base=main
+      - "label=backport-humble"
+    actions:
+      backport:
+        branches:
+          - humble
+
+  - name: delete head branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch:
+
+  - name: ask to resolve conflict
+    conditions:
+      - conflict
+      - author!=mergify
+    actions:
+        comment:
+          message: This pull request is in conflict. Could you fix it @{{author}}?
+
+  - name: development targets main branch
+    conditions:
+      - base!=main
+      - author!=LihanChen2004
+      - author!=mergify
+    actions:
+        comment:
+          message: |
+            @{{author}}, all pull requests must be targeted towards the `main` development branch.
+            Once merged into `main`, it is possible to backport to @{{base}}, but it must be in `main`
+            to have these changes reflected into new distributions.
+
+  - name: Main build failures
+    conditions:
+      - base=main
+      - or:
+        - "check-failure=build-and-test"
+    actions:
+        comment:
+          message: |
+            @{{author}}, your PR has failed to build. Please check CI outputs and resolve issues.
+            You may need to rebase or pull in `main` due to API changes (or your contribution genuinely fails).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-desktop-latest
+      image: rostooling/setup-ros-docker:ubuntu-jammy-ros-jazzy-desktop-latest
     steps:
       - name: Build pb_omni_pid_pursuit_controller
         uses: ros-tooling/action-ros-ci@v0.3
         with:
           package-name: pb_omni_pid_pursuit_controller
-          target-ros2-distro: humble
+          target-ros2-distro: jazzy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-ubuntu-noble-ros-jazzy-ros-base
+      image: rostooling/setup-ros-docker:ubuntu-noble-ros-jazzy-ros-base-latest
     steps:
       - name: Build pb_omni_pid_pursuit_controller
         uses: ros-tooling/action-ros-ci@v0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-jammy-ros-jazzy-desktop-latest
+      image: ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-ubuntu-noble-ros-jazzy-ros-base
     steps:
       - name: Build pb_omni_pid_pursuit_controller
-        uses: ros-tooling/action-ros-ci@v0.3
+        uses: ros-tooling/action-ros-ci@v0.4
         with:
           package-name: pb_omni_pid_pursuit_controller
           target-ros2-distro: jazzy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-desktop-latest
     steps:
-      - name: Build small_gicp_relocalization
+      - name: Build pb_omni_pid_pursuit_controller
         uses: ros-tooling/action-ros-ci@v0.3
         with:
           package-name: pb_omni_pid_pursuit_controller

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,12 @@
+name: pre-commit
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  pre-commit:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-pre-commit.yml@master
+    with:
+      ros_distro: humble

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,4 +9,4 @@ jobs:
   pre-commit:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-pre-commit.yml@master
     with:
-      ros_distro: humble
+      ros_distro: jazzy

--- a/src/omni_pid_pursuit_controller.cpp
+++ b/src/omni_pid_pursuit_controller.cpp
@@ -14,7 +14,7 @@
 
 #include "pb_omni_pid_pursuit_controller/omni_pid_pursuit_controller.hpp"
 
-#include "nav2_core/exceptions.hpp"
+#include "nav2_core/planner_exceptions.hpp"
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_util/node_utils.hpp"
 


### PR DESCRIPTION
This PR updates a Jazzy-incompatible include:

```diff
- #include "nav2_core/exceptions.hpp"
+ #include "nav2_core/planner_exceptions.hpp"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal references for exception handling to use a different header source. No changes to functionality or user experience.
  - Added automated pull request management with branch targeting rules and conflict handling.
  - Updated continuous integration workflow to use the latest ROS 2 distribution.
  - Introduced a new pre-commit check workflow to improve code quality enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->